### PR TITLE
Django 1.6+ compliance

### DIFF
--- a/change_email/urls.py
+++ b/change_email/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import *
+except ImportError:
+    from django.conf.urls import patterns, url
 
 from change_email.views import EmailChangeConfirmView
 from change_email.views import EmailChangeCreateView


### PR DESCRIPTION
django.conf.urls.defaults was removed in Django 1.6, so the existing urls.py throws an ImportError; this change makes it work under 1.6+.
